### PR TITLE
add a example

### DIFF
--- a/docs/parts/wokwi-logic-analyzer.md
+++ b/docs/parts/wokwi-logic-analyzer.md
@@ -54,3 +54,7 @@ For usage examples, check out the [Using the Trigger section](../guides/logic-an
 When you stop the simulation, the logic analyzer downloads a file with the recorded samples to your computer. The recording file uses the standard [Value Change Dump (VCD)](https://en.wikipedia.org/wiki/Value_change_dump) format. The file is called "wokwi-logic.vcd" by default, but you can configure the name using the `filename` attribute.
 
 To learn how to view the data, please visit our [Logic Analyzer Guide](../guides/logic-analyzer#using-the-logic-analyzer).
+
+## Simulator examples
+
+- [Sketch that makes signals for the Logic Analyzer](https://wokwi.com/projects/325933824665977428)


### PR DESCRIPTION
The Logic Analyzer did not have an example.
The sketch has explanation about the appropriate decoders in PulseView.