### PR TITLE
Adds Serial.begin to esp32-wifi guide

### DIFF
--- a/docs/guides/esp32-wifi.md
+++ b/docs/guides/esp32-wifi.md
@@ -21,6 +21,7 @@ To connect from Arduino (on an ESP32) device, use the following code:
 #include <WiFi.h>
 
 void setup() {
+  Serial.begin(9600);
   Serial.print("Connecting to WiFi");
   WiFi.begin("Wokwi-GUEST", "", 6);
   while (WiFi.status() != WL_CONNECTED) {


### PR DESCRIPTION
Without Serial.begin(<value>), the user won't be able to print values through the serial monitor.

Without Serial.begin()
![image](https://user-images.githubusercontent.com/24274916/171852021-33077651-4d43-4493-b141-5338c9616a68.png)

With Serial.begin()
![image](https://user-images.githubusercontent.com/24274916/171851976-ed4bcb85-398d-42b3-9da0-db493c0d67b9.png)

Hence, the addition will make it easier for new users to test and visualize the demo! 