### PR TITLE
Update wokwi-hx711.md to add HX711_ADC Calibration demo

### DIFF
--- a/docs/parts/wokwi-hx711.md
+++ b/docs/parts/wokwi-hx711.md
@@ -66,3 +66,4 @@ Try [this example on Wokwi](https://wokwi.com/projects/345134808605655636)
 
 - [HX711 demo](https://wokwi.com/projects/344192176616374868)
 - [Digital scale](https://wokwi.com/projects/336613701830312531)
+- [HX711_ADC Calibration demo](https://wokwi.com/projects/407626388355231745)


### PR DESCRIPTION
Add https://wokwi.com/projects/407626388355231745 -- A calibration demo from https://github.com/olkal/HX711_ADC/blob/master/examples/Calibration/Calibration.ino

This example allows the user to calibrate the sensor through the serial monitor with a tare and known weight.

The program was slightly modified to use the same pins as the other Wokwi demos, and also print only changed readings.