### PR TITLE
[FIX][DOCS](PT-br) board-ssd1306.md #216

### DIFF
--- a/i18n/pt-BR/docusaurus-plugin-content-docs/current/parts/board-ssd1306.md
+++ b/i18n/pt-BR/docusaurus-plugin-content-docs/current/parts/board-ssd1306.md
@@ -30,7 +30,7 @@ Você pode escolher entre várias bibliotecas SSD1306 do Arduino:
 
 - [Adafruit SSD1306](https://wokwi.com/projects/344892392214626898)
 - [ssd1306](https://wokwi.com/projects/344894074741850707)
-- [lcdgfx](https://wokwi.com/lexus2k/lcdgfx)
+- [lcdgfx](https://github.com/lexus2k/lcdgfx)
 - [U8glib](https://github.com/olikraus/u8glib)
 - [U8g2](https://github.com/olikraus/u8g2) (também U8x8)
 - [SSD1306Ascii](https://github.com/greiman/SSD1306Ascii)


### PR DESCRIPTION
Fixed problem mentioned in #216

Link with wrong host, instead of `github.com` it was `wokwi.com`
In the original version there is no such error

`lcdgfx` in https://docs.wokwi.com/pt-BR/parts/board-ssd1306
- ❌ lcdgfx https://wokwi.com/lexus2k/lcdgfx
- ✔ lcdgfx https://github.com/lexus2k/lcdgfx

<!--
Link com host errado, em vez de github.com era wokwi.com
na versão original não existe esse erro
-->