### PR TITLE
docs(wokwi-ci): add supported parts section for automation controls

### DIFF
--- a/docs/wokwi-ci/automation-scenarios.md
+++ b/docs/wokwi-ci/automation-scenarios.md
@@ -27,3 +27,15 @@ steps:
 :::warning
 Automation scenarios are currently in alpha. The API is not fully documented yet, and may change in the future. You can use the [example projects](github-actions#examples) as a reference.
 :::
+
+## Supported Parts with Automation Controls
+
+Several Wokwi parts support automation controls that can be controlled using automation scenarios. These controls allow you to programmatically change the state of sensors, press buttons, and modify component values during simulation.
+
+### Parts with Automation Controls
+
+- **[Push Button](../parts/wokwi-pushbutton#automation-controls)** - Control button presses and releases
+- **[Potentiometer](../parts/wokwi-potentiometer#automation-controls)** - Adjust the potentiometer position
+- **[MPU6050 Sensor](../parts/wokwi-mpu6050#automation-controls)** - Set acceleration, rotation, and temperature values
+
+Each part's documentation page contains detailed information about the specific automation controls available, including control names, types, and example usage.


### PR DESCRIPTION
Added a new section to the Wokwi Automation Scenarios documentation that lists all parts supporting automation controls, making it easier for users to discover which components can be controlled programmatically during simulation.