### PR TITLE
Add <kbd> tags to shortcut page

### DIFF
--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -5,25 +5,25 @@ sidebar_label: Keyboard Shortcuts
 
 ## General shortcuts
 
-| Description                     | Windows / Linux | Mac     |
-| ------------------------------- | --------------- | ------- |
-| Start simulation                | Ctrl + Enter    | ⌘ Enter |
-| Save project                    | Ctrl + S        | ⌘ S     |
-| Auto format code                | Alt + Shift + F | ⌥ ⇧ F   |
-| Trigger auto complete           | Ctrl + Space    | ⌘ Space |
-| Show list of available commands | F1              | F1      |
-| Jump to next error in file      | F8              | F8      |
-| Jump to previous error in file  | Shift + F8      | ⇧ F8    |
+| Description                     | Windows / Linux                                  | Mac                                        |
+|---------------------------------|--------------------------------------------------|--------------------------------------------|
+| Start simulation                | <kbd>Ctrl</kbd> + <kbd>Enter</kbd>               | <kbd>⌘</kbd> + <kbd>Enter</kbd>            |
+| Save project                    | <kbd>Ctrl</kbd> + <kbd>S</kbd>                   | <kbd>⌘</kbd> + <kbd>S</kbd>                |
+| Auto format code                | <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>F</kbd> | <kbd>⌥</kbd> + <kbd>⇧</kbd> + <kbd>F</kbd> |
+| Trigger auto complete           | <kbd>Ctrl</kbd> + <kbd>Space</kbd>               | <kbd>⌘</kbd> + <kbd>Space</kbd>            |
+| Show list of available commands | <kbd>F1</kbd>                                    | <kbd>F1</kbd>                              |
+| Jump to next error in file      | <kbd>F8</kbd>                                    | <kbd>F8</kbd>                              |
+| Jump to previous error in file  | <kbd>Shift</kbd> + <kbd>F8</kbd>                 | <kbd>⇧</kbd> + <kbd>F8</kbd>               |
 
 ## Basic editing keys
 
-| Description                | Windows / Linux | Mac |
-| -------------------------- | --------------- | --- |
-| Indent line\*              | Ctrl + ]        | ⌘ ] |
-| Outdent line\*             | Ctrl + [        | ⌘ [ |
-| Comment / uncomment line\* | Ctrl + /        | ⌘ / |
-| Find in file               | Ctrl + F        | ⌘ F |
-| Replace                    | Ctrl + H        | ⌘ H |
+| Description                | Windows / Linux                | Mac                         |
+|----------------------------|--------------------------------|-----------------------------|
+| Indent line\*              | <kbd>Ctrl</kbd> + <kbd>]</kbd> | <kbd>⌘</kbd> + <kbd>]</kbd> |
+| Outdent line\*             | <kbd>Ctrl</kbd> + <kbd>[</kbd> | <kbd>⌘</kbd> + <kbd>[</kbd> |
+| Comment / uncomment line\* | <kbd>Ctrl</kbd> + <kbd>/</kbd> | <kbd>⌘</kbd> + <kbd>/</kbd> |
+| Find in file               | <kbd>Ctrl</kbd> + <kbd>F</kbd> | <kbd>⌘</kbd> + <kbd>F</kbd> |
+| Replace                    | <kbd>Ctrl</kbd> + <kbd>H</kbd> | <kbd>⌘</kbd> + <kbd>H</kbd> |
 
 \* if you have selected some text, this will operate on the selection instead of the current line
 
@@ -32,17 +32,17 @@ sidebar_label: Keyboard Shortcuts
 These keyboard shortcuts enable powerful editing operations, such as managing
 multiple cursors / selections.
 
-| Description                             | Windows / Linux     | Mac       |
-| --------------------------------------- | ------------------- | --------- |
-| Select word at cursor / next occurrence | Ctrl + D            | ⌘ D       |
-| Select all occurrences                  | Ctrl + Shift + L    | ⌘ ⇧ L     |
-| Duplicate line\* above                  | Alt + Shift + Up    | ⌥ ⇧ Up    |
-| Duplicate line\* below                  | Alt + Shift + Down  | ⌥ ⇧ Down  |
-| Move current line\* up                  | Alt + Up            | ⌥ Up      |
-| Move current line\* down                | Alt + Down          | ⌥ Down    |
-| Add cursor above                        | Ctrl + Alt + Up     | ⌘ ⌥ Up    |
-| Add cursor below                        | Ctrl + Alt + Down   | ⌘ ⌥ Down  |
-| Expand selection                        | Alt + Shift + Right | ⌥ ⇧ Right |
-| Shrink selection                        | Alt + Shift + Left  | ⌥ ⇧ Left  |
+| Description                             | Windows / Linux                                      | Mac                                            |
+|-----------------------------------------|------------------------------------------------------|------------------------------------------------|
+| Select word at cursor / next occurrence | <kbd>Ctrl</kbd> + <kbd>D</kbd>                       | <kbd>⌘</kbd> + <kbd>D</kbd>                    |
+| Select all occurrences                  | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>L</kbd>    | <kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>L</kbd>     |
+| Duplicate line\* above                  | <kbd>Alt</kbd> + <kbd>Shift</kbd> + Up               | <kbd>⌥</kbd> + <kbd>⇧</kbd> + <kbd>Up</kbd>    |
+| Duplicate line\* below                  | <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>Down</kbd>  | <kbd>⌥</kbd> + <kbd>⇧</kbd> + <kbd>Down</kbd>  |
+| Move current line\* up                  | <kbd>Alt</kbd> + <kbd>Up</kbd>                       | <kbd>⌥</kbd> + <kbd>Up</kbd>                   |
+| Move current line\* down                | <kbd>Alt</kbd> + <kbd>Down</kbd>                     | <kbd>⌥</kbd> + <kbd>Down</kbd>                      |
+| Add cursor above                        | <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Up</kbd>     | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>Up</kbd>    |
+| Add cursor below                        | <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Down</kbd>   | <kbd>⌘</kbd> + <kbd>⌥</kbd> + <kbd>Down</kbd>  |
+| Expand selection                        | <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>Right</kbd> | <kbd>⌥</kbd> + <kbd>⇧</kbd> + <kbd>Right</kbd> |
+| Shrink selection                        | <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>Left</kbd>  | <kbd>⌥</kbd> + <kbd>⇧</kbd> + <kbd>Left</kbd>  |
 
 \* if you selected some text, this will operate on the selection instead of the current line


### PR DESCRIPTION
This is a bit of a driveby, which just adds the HTML `<kbd>` tag to the specified keys in the shortcut table. There are two reasons for this:
 - it makes the output a little easier to read and distinguish between text and keys
 - it is more accessible: the `<kbd>`tag is understood and processed correctly by screen readers etc. 