### PR TITLE
Add frontmatter

### DIFF
--- a/docs/diagram-format.md
+++ b/docs/diagram-format.md
@@ -1,6 +1,8 @@
 ---
 title: diagram.json File Format
 sidebar_label: diagram.json
+description: Reference guide for the `diagram.json` file for Wokwi simulation projects. This file defines components, their attributes, layout positions, and the connections between them.
+keywords: [diagram.json, connections, wiring, component layout, virtual hardware, ESP32, STM32, Arduino, wire placement, simulation diagram, simulation editor]
 ---
 
 Each simulation project contains a diagram.json file. This file defines the components

--- a/docs/gdb-debugging.md
+++ b/docs/gdb-debugging.md
@@ -1,6 +1,8 @@
 ---
 title: GDB Debugging (Advanced)
 sidebar_label: GDB Debugging
+description: Use GDB to debug Arduino and Raspberry Pi Pico code directly in the Wokwi simulator. This guide describes how to launch a web-based GDB session, step through code, set breakpoints and inspect variables.
+keywords: [GDB, debugging, Arduino, Raspberry Pi Pico, web gdb, gdb commands, breakpoint, gdb cheatsheet, sketch.ino, step-through debugging, avr debugging]
 ---
 
 GDB is a powerful source code debugger. You can use it to debug your Arduino and Raspberry Pi Pico code in Wokwi.

--- a/docs/guides/circuitpython.md
+++ b/docs/guides/circuitpython.md
@@ -1,6 +1,8 @@
 ---
 title: CircuitPython on Wokwi
 sidebar_label: CircuitPython
+description: Simulate CircuitPython on Wokwi using the Raspberry Pi Pico. This guide covers project setup, using Adafruit libraries, and exploring the CircuitPython REPL.
+keywords: [CircuitPython, Wokwi, Raspberry Pi Pico, CircuitPython simulation, CircuitPython REPL, Adafruit CircuitPython, embedded Python, Wokwi tutorial]
 ---
 
 You can simulate CircuitPython on Wokwi using the [Raspberry Pi Pico board](../parts/wokwi-pi-pico). To start a new simulation project, open the [Raspberry Pi Pico CircuitPython project template](https://wokwi.com/projects/new/circuitpython-pi-pico).

--- a/docs/guides/debugger.md
+++ b/docs/guides/debugger.md
@@ -1,10 +1,18 @@
-# Interactive Debugger
+---
+title: Interactive debugger
+sidebar_label: Interactive debugger
+description: Use Wokwi's built-in interactive debugger to step through code, set breakpoints, inspect variables, and explore call stacks.
+keywords: [Wokwi debugger, interactive debugger, Arduino debug, step through, breakpoints]
+---
+
+
+# Interactive debugger
 
 Wokwi has a built-in debugger that allows you to step through your code, inspect variables, and set breakpoints. The debugger is currently in beta, and is available for AVR microcontrollers: Arduino Uno, Arduino Nano, Arduino Mega, and the ATtiny85.
 
-If you wish to debug other microcontrollers, such as the ESP32 or the Raspberry Pi Pico, you can use [Wokwi for VSCode](../vscode/getting-started), which has an [integrated debugger support](../vscode/debugging).
+If you wish to debug other microcontrollers, such as the ESP32 or the Raspberry Pi Pico, you can use [Wokwi for VSCode](../vscode/getting-started), which has [integrated debugger support](../vscode/debugging).
 
-## Using the Debugger
+## Using the debugger
 
 To start debugging your code, click the menu button in the simulator toolbar, and select **Debug**:
 
@@ -22,11 +30,11 @@ When running in debug mode, you will see the debug toolbar above the code editor
 
 - **Step out** - Step out of the current function.
 
-## Debugging Panes
+## Debugging panes
 
 The debugging panes appear when you pause the program (either manually, or at a breakpoint). You'll find the panes below the diagram, next to the [Serial Monitor](./serial-monitor) pane.
 
-### Call Stack
+### Call stack
 
 The call stack shows the current function call stack. The top of the stack is the currently executing function. The bottom of the stack is the main function.
 

--- a/docs/guides/diagram-editor.md
+++ b/docs/guides/diagram-editor.md
@@ -1,9 +1,12 @@
 ---
 title: Interactive Diagram Editor
 sidebar_label: Diagram Editor
+description: Use the Wokwi Diagram Editor to visually build and edit circuit simulations. Add components, wire connections, rotate, duplicate, and manage parts with the help of intuitive keyboard shortcuts and grid snapping.
+keywords: [Wokwi diagram editor, diagram.json, visual circuit builder]
+
 ---
 
-The diagram editor provides an interactive way to edit your diagram: add components to the simulation and define the connections between them. It's a convenient alternative for editing the [diagram.json](../diagram-format) file directly.
+The diagram editor provides an interactive way to edit your circuit diagram: add components to the simulation and define the connections between them. It's a convenient alternative for editing the [diagram.json](../diagram-format) file directly.
 
 ## Editing parts
 

--- a/docs/guides/esp32-wifi.md
+++ b/docs/guides/esp32-wifi.md
@@ -1,6 +1,8 @@
 ---
 title: ESP32 WiFi Networking
 sidebar_label: ESP32 WiFi
+description: Simulate WiFi and internet access for ESP32 projects using Wokwi, including public/private gateways, HTTP/MQTT, and local networking.
+keywords: [ ESP32, WiFi, IoT, MQTT, Private Gateway, MicroPython, Arduino]
 ---
 
 Wokwi simulates a WiFi network with full internet access. You can use the [ESP32](./esp32) together with the virtual WiFi to prototype IoT projects. Common use cases include:

--- a/docs/guides/esp32.md
+++ b/docs/guides/esp32.md
@@ -1,6 +1,8 @@
 ---
 title: ESP32 Simulation
 sidebar_label: ESP32 Simulator
+description: Simulate espressif ESP32 boards in Wokwi
+keywords: [ESP32, ESP32 Simulation, ESP32, ESP32-C3, ESP32-S2, ESP32-S3, ESP32-C6, ESP32-H2, MicroPython, Arduino, Rust, IoT, VSCode, ESP-IDF]
 ---
 
 The ESP32 is a popular WiFi and Bluetooth-enabled microcontroller, widely used for IoT Projects. Wokwi simulates the ESP32, ESP32-C3, ESP32-S2, ESP32-S3, ESP32-C6, ESP32-H2, and ESP32-P4 (beta).

--- a/docs/guides/libraries.md
+++ b/docs/guides/libraries.md
@@ -1,6 +1,8 @@
 ---
 title: Arduino Libraries
 sidebar_label: Libraries
+description: Add built-in, third-party, and custom Arduino libraries to your Wokwi projects using the Library Manager and the libraries.txt file.
+keywords: [Arduino libraries, Library Manager, libraries.txt, custom libraries, upload library, Arduino Library Manager, Arduino includes]
 ---
 
 To include a library, go to the code editor and type `#` on an empty line. You'll see a autocomplete dropdown with `#include` suggestions for popular libraries.

--- a/docs/guides/logic-analyzer.md
+++ b/docs/guides/logic-analyzer.md
@@ -1,6 +1,8 @@
 ---
 title: Logic Analyzer Guide
 sidebar_label: Logic Analyzer
+description: Use the Wokwi Logic Analyzer to debug and visualize digital signals, record VCD files, and analyze protocols using PulseView or GTKWave.
+keywords: [Logic Analyzer, Wokwi, VCD file, PulseView, GTKWave, I2C debugging, PWM, PIO, Raspberry Pi Pico, downsampling]
 ---
 
 import LogicAnalyzerI2CImage from './logic-analyzer-i2c-decoder.png';

--- a/docs/guides/micropython.md
+++ b/docs/guides/micropython.md
@@ -1,6 +1,8 @@
 ---
 title: MicroPython on Wokwi
 sidebar_label: MicroPython
+description: Create and run MicroPython projects in Wokwi using the Raspberry Pi Pico simulator.
+keywords: [MicroPython, Wokwi, Raspberry Pi Pico, main.py, REPL, flash filesystem, MicroPython simulation]
 ---
 
 You can create and run MicroPython projects on Wokwi. Start from the [Raspberry Pi Pico MicroPython project template](https://wokwi.com/projects/new/micropython-pi-pico).

--- a/docs/guides/serial-monitor.md
+++ b/docs/guides/serial-monitor.md
@@ -1,6 +1,8 @@
 ---
 title: The Serial Monitor
 sidebar_label: Serial Monitor
+description: Interact with the serial interface of the Wokwi simulation to view output or send data.
+keywords: [Serial, USART, TX, RX, Arduino]
 ---
 
 The Serial Monitor provides a way to send/receive information to/from your Arduino code.

--- a/docs/guides/translating.md
+++ b/docs/guides/translating.md
@@ -1,6 +1,7 @@
 ---
 title: Translating Wokwi
 sidebar_label: Translating
+description: Help to translate this documentation into the languages of the world.
 ---
 
 This page explains how you can contribute translations to Wokwi.

--- a/docs/vscode/debugging.md
+++ b/docs/vscode/debugging.md
@@ -1,6 +1,8 @@
 ---
 title: Debugging your code
 sidebar_label: Debugging
+description: Configure and use the VS Code debugger to debug code running in the Wokwi simulator, with support for AVR, ESP32, ESP-IDF, and PlatformIO projects.
+keywords: [debugger, GDB, VS Code, ESP32, ESP-IDF, AVR, PlatformIO, launch.json,  Visual Studio Code]
 ---
 
 You can debug your code while it is running in the simulation using the VS Code debugger. To set up the debugger, follow these steps:

--- a/docs/vscode/diagram-editor.md
+++ b/docs/vscode/diagram-editor.md
@@ -1,6 +1,8 @@
 ---
 title: Diagram Editor in VS Code
 sidebar_label: Diagram Editor
+description: Use the visual diagram editor in Wokwi for VS Code to open and edit diagrams, and run the simulation.
+keywords: [VS Code, diagram editor, visual editor, diagram.json, simulation]
 ---
 
 # Diagram Editor in VS Code

--- a/docs/vscode/getting-started.md
+++ b/docs/vscode/getting-started.md
@@ -1,6 +1,8 @@
 ---
 title: Getting Started with Wokwi for VS Code
 sidebar_label: Getting Started
+description:  Simulate embedded and IoT projects directly inside Visual Studio Code using the Wokwi extension. Supports PlatformIO, ESP-IDF, Arduino, MicroPython, Rust, Zephyr and more.
+keywords: [Visual Studio Code, VS Code, embedded simulation, IoT simulation, PlatformIO, ESP-IDF, Arduino, MicroPython, Rust, Zephyr]
 ---
 
 # Wokwi for VS Code

--- a/docs/vscode/offline-mode.md
+++ b/docs/vscode/offline-mode.md
@@ -1,6 +1,8 @@
 ---
 title: Running Wokwi Offline
 sidebar_label: Offline Mode
+description: Running the simulation offline or in restricted network environments.
+keywords: [ internet, network, offline]
 ---
 
 Wokwi for VS Code requires an internet connection to run. If you need to use Wokwi for VS Code in an environment without internet access, you can subscribe to the [Pro plan](https://wokwi.com/pricing).

--- a/docs/vscode/project-config.md
+++ b/docs/vscode/project-config.md
@@ -1,6 +1,8 @@
 ---
 title: Configuring Your Project (wokwi.toml)
 sidebar_label: Project Config
+description: Configure your project using wokwi.toml and diagram.json files, including firmware paths, serial forwarding, custom chips, and network settings.
+keywords: [wokwi.toml, diagram.json, Wokwi project setup, serial forwarding, custom chips, ESP32 WiFi forwarding]
 ---
 
 To simulate your project on Wokwi, you need to create two files in your project's root directory:

--- a/docs/wokwi-ci/automation-scenarios.md
+++ b/docs/wokwi-ci/automation-scenarios.md
@@ -1,6 +1,8 @@
 ---
 title: Wokwi Automation Scenarios
 sidebar_label: Automation Scenarios
+description: Automate simulations in Wokwi using YAML-based automation scenarios. Simulate button presses, sensor input, and verify serial output to test firmware programmatically.
+keywords: [automation, simulation testing, YAML automation scenarios, embedded simulation, automated firmware testing, sensor state simulation]
 ---
 
 Automation scenarios allow you to automate the simulation, push buttons, change the state of the sensors, and check the serial output. You can use automation scenarios to test your firmware in a realistic environment, and verify that it behaves as expected.

--- a/docs/wokwi-ci/cli-installation.md
+++ b/docs/wokwi-ci/cli-installation.md
@@ -1,6 +1,8 @@
 ---
 title: Wokwi CLI Installation
 sidebar_label: CLI Installation
+description: Install the CLI to run and automate Wokwi simulations from your terminal.
+keywords: [CLI, terminal, CI, Powershell, wokwi-cli]
 ---
 
 The CLI allows you to run Wokwi simulations from your terminal, and integrate them with your CI system. We recommend using the [Wokwi for VS Code](../vscode/getting-started) extension for local development, and the CLI for running your tests on CI.

--- a/docs/wokwi-ci/cli-usage.md
+++ b/docs/wokwi-ci/cli-usage.md
@@ -1,6 +1,8 @@
 ---
 title: Wokwi CLI Usage
 sidebar_label: CLI Usage
+description: Wokwi CLI command reference
+keywords: [ reference, Wokwi, CLI, API, CI Dashboard, serial monitor]
 ---
 
 Create an API token on the [Wokwi CI Dashboard](https://wokwi.com/dashboard/ci). Set the `WOKWI_CLI_TOKEN` environment variable to the token value.

--- a/docs/wokwi-ci/getting-started.md
+++ b/docs/wokwi-ci/getting-started.md
@@ -1,6 +1,9 @@
 ---
 title: Wokwi for CI and GitHub Actions
 sidebar_label: Introduction
+description: Use Wokwi CI to automate embedded firmware testing in continuous integration workflows like GitHub Actions and GitLab CI. Learn about WITL (Wokwi in the Loop), automation scenarios, simulation limits, and integrating with AI agents using MCP.
+
+keywords: [Wokwi CI, embedded testing, continuous integration, GitHub Actions, GitLab CI, firmware simulation, automation scenarios, Wokwi CLI, WITL, Model Context Protocol, MCP, AI-assisted development, simulation limits, embedded workflows]
 ---
 
 Wokwi provides a robust simulation solution for automated testing of your embedded firmware on CI systems like [GitHub Actions](./github-actions), GitLab CI, and others. You can use Wokwi to run your tests on every commit, and get instant feedback on your code changes.

--- a/docs/wokwi-ci/getting-started.md
+++ b/docs/wokwi-ci/getting-started.md
@@ -17,7 +17,7 @@ For more advanced testing scenarios, you can write [automation scenarios](./auto
 
 ## CI Architecture
 
-Wokwi CI is powered a simulation server that runs in the cloud. The server receives your firmware binary, simulates it, and streams the serial output back to your CI system. The server is stateless and can run multiple simulations in parallel.
+Wokwi CI is powered by a simulation server that runs in the cloud. The server receives your firmware binary, simulates it, and streams the serial output back to your CI system. The server is stateless and can run multiple simulations in parallel.
 
 Wokwi does not store your firmware, and it is deleted from the cloud server after the simulation is finished. If you do not want to upload your firmware to the cloud, please contact us to discuss options for on-premise deployment of Wokwi CI.
 

--- a/docs/wokwi-ci/github-actions.md
+++ b/docs/wokwi-ci/github-actions.md
@@ -1,6 +1,8 @@
 ---
 title: Using Wokwi in GitHub Actions
 sidebar_label: Github Actions
+description: Integrate Wokwi CI with GitHub Actions to automatically test your embedded firmware on every commit. 
+keywords: [GitHub Actions, embedded testing, firmware automation, CI/CD, automation scenarios, CI workflows, embedded projects, continuous integration]
 ---
 
 You can use Wokwi CI with GitHub Actions to run your tests on every commit. You need to have a workflow that builds your project's firmware. Add the following step to your workflow:
@@ -16,7 +18,7 @@ You can use Wokwi CI with GitHub Actions to run your tests on every commit. You 
 
 For a complete list of options, check out the [action's README](https://github.com/wokwi/wokwi-ci-action?tab=readme-ov-file#usage).
 
-## CLI Tokens
+## CLI tokens
 
 You also need to set up the `WOKWI_CLI_TOKEN` secret in your repository settings. You can create an API token on the [Wokwi CI Dashboard](https://wokwi.com/dashboard/ci).
 

--- a/docs/wokwi-ci/mcp-support.md
+++ b/docs/wokwi-ci/mcp-support.md
@@ -1,8 +1,14 @@
+---
+title: Model Context Protocola (MCP) support
+sidebar_label: MCP support
+description: Integrate AI agents like Copilot, Claude, Cursor, Gemini, and ChatGPT with Wokwi using the Model Context Protocol (MCP). This guide covers configuring the Wokwi MCP server, enabling real-time simulation, automated testing, and virtual hardware interaction.
+keywords: [MCP, Model Context Protocol, AI integration, Copilot, Claude, ChatGPT, Gemini, Cursor, automated testing, serial console]
+---
+
+
 # MCP Support
 
-## What is MCP?
-
-The Model Context Protocol (MCP) is an open standard that allows AI agents—such as Copilot, Claude Code, Cursor, and others to securely interact with external tools and services. For Wokwi users, MCP enables seamless integration between AI assistants and embedded simulation.
+The Model Context Protocol (MCP) is an open standard that allows AI agents—such as Copilot, Claude Code, Cursor, Gemini, ChatGPT and others to securely interact with external tools and services. For Wokwi users, MCP enables seamless integration between AI assistants and embedded simulation.
 
 ## Wokwi MCP Server
 


### PR DESCRIPTION
Some sections of docs were missing frontmatter entirely or in part. This adds slightly more optimised descriptions, which are good for discoverability (and also used by search engines).
I also added keywords - these aren't as important these days as many search engines don't use them any more, but some indexing and linking automation does, so it doesn't hurt to add.