### PR TITLE
docs(wokwi-ci/automation): expand automation scenarios documentation

### DIFF
--- a/docs/wokwi-ci/automation-scenarios.md
+++ b/docs/wokwi-ci/automation-scenarios.md
@@ -215,5 +215,8 @@ Several Wokwi parts support automation controls that can be controlled using aut
 - **[Push Button](../parts/wokwi-pushbutton#automation-controls)** - Control button presses and releases
 - **[Potentiometer](../parts/wokwi-potentiometer#automation-controls)** - Adjust the potentiometer position
 - **[MPU6050 Sensor](../parts/wokwi-mpu6050#automation-controls)** - Set acceleration, rotation, and temperature values
+- **[Analog Joystick](../parts/wokwi-analog-joystick#automation-controls)** - Set direction and pressed state
+- **[HX711 Load Cell Amplifier](../parts/wokwi-hx711#automation-controls)** - Set load value of scale
+- **[Photoresistor Sensor](../parts/wokwi-photoresistor-sensor#automation-controls)** - Set lux
 
 Each part's documentation page contains detailed information about the specific automation controls available, including control names, types, and example usage.


### PR DESCRIPTION
This PR expands upon the existing automation scenario documentation by adding information from the README of [wokwi-part-test](https://github.com/wokwi/wokwi-part-tests/blob/f6ab884efde4394f9072b2006f86d924b59831f8/README.md), adding a list of available steps (with parameters and example usage) from the [wokwi-cli implementation](https://github.com/wokwi/wokwi-cli/tree/786fa8e49d9c9bde01b43ea5aac9cc161b5b0675/src/scenario), and adding some extra parts which have automation control available.