### PR TITLE
docs(parts): add wokwi-clock-generator page

### DIFF
--- a/docs/parts/wokwi-clock-generator.md
+++ b/docs/parts/wokwi-clock-generator.md
@@ -1,0 +1,32 @@
+---
+title: wokwi-clock-generator Reference
+sidebar_label: wokwi-clock-generator
+---
+
+Configurable clock generator component.
+
+![](wokwi-clock-generator.svg)
+
+## Pin names
+
+| Name | Description         |
+| :--- | :------------------ |
+| CLK  | Clock signal output |
+
+## Attributes
+
+| Name | Description | Default value |
+| :--- | :---------- | :------------ |
+| frequency | Set the frequency of the generator (in Hz) | "10k" |
+
+You can suffix your value with "k" or "m" to get KHz or MHz values. For example:
+- "10k" is a 10KHz clock
+- "1.3m" is a 1.3MHz clock
+- "1" is a 1Hz clock
+
+:::warning
+Frequencies over 100KHz may slow down the simulation.
+:::
+
+## Simulator Examples
+- [Tiny Tapeout Template](https://wokwi.com/projects/354858054593504257)

--- a/docs/parts/wokwi-clock-generator.svg
+++ b/docs/parts/wokwi-clock-generator.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="29mm"
+   height="29mm"
+   viewBox="0 0 29 29"
+   version="1.1"
+   id="svg10"
+   sodipodi:docname="wokwi-clock-generator.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <style>
+   path {
+      stroke: black;
+   }
+
+   @media (prefers-color-scheme: dark) {
+      path {
+         stroke: white;
+      }
+   }
+  </style>
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     id="namedview12"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="9.3698994"
+     inkscape:cx="28.762315"
+     inkscape:cy="54.749787"
+     inkscape:window-width="2560"
+     inkscape:window-height="1380"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg10" />
+  <g
+     stroke-width="0.4"
+     fill="none"
+     transform="translate(0.53,9.4975773)"
+     id="g8">
+    <path
+       d="M 16,5.08 H 28"
+       id="path2" />
+    <path
+       d="M 0.315,0.2 h 15.455 v 9.63 h -15.455 Z"
+       id="path4" />
+    <path
+       d="M 0,6.562 h 3.116 v -5.08 h 3.116 v 5.08 h 3.116 v -5.08 h 3.116 v 5.08 h 3.116"
+       stroke="#fcf7fd"
+       id="path6"/>
+  </g>
+</svg>

--- a/sidebars.js
+++ b/sidebars.js
@@ -34,6 +34,7 @@ module.exports = {
       'parts/wokwi-attiny85',
       'parts/wokwi-biaxial-stepper',
       'parts/wokwi-buzzer',
+      'parts/wokwi-clock-generator',
       'parts/wokwi-dht22',
       'parts/wokwi-dip-switch-8',
       'parts/wokwi-ds1307',


### PR DESCRIPTION
Ref #265 

This PR adds a page for the wowki-clock-generator component. It's somewhat sparse, but has all the info from the online editor.

I also edited the SVG used for the component to make sure that it works properly with the light/dark mode switching.