### PR TITLE
docs(wokwi-ci): mention `idf-wokwi` extension

### DIFF
--- a/docs/wokwi-ci/cli-installation.md
+++ b/docs/wokwi-ci/cli-installation.md
@@ -29,3 +29,5 @@ it from `idf.py`. To install it, simply run the following command:
 ```bash
 pip install idf-wokwi
 ```
+
+Read more about `idf-wokwi` on our [ESP-IDF simulation extension](idf-wokwi-usage) page.

--- a/docs/wokwi-ci/cli-usage.md
+++ b/docs/wokwi-ci/cli-usage.md
@@ -51,32 +51,6 @@ You can use the following options to customize the CLI behavior:
 - `--help`, `-h` - Prints help information and exit
 - `--quiet`, `-q` - Quiet: do not print version or status messages
 
-## Wokwi ESP-IDF Simulation Extension
-
-After running `pip install idf-wokwi`, you can now access simulation features from `idf.py`. You must first configure
-the `WOKWI_CLI_TOKEN` environment variable by creating an API token on the
-[Wokwi CI Dashboard](https://wokwi.com/dashboard/ci). To start a simulation, run `idf.py wokwi`. This command accepts a
-set of options to customize its behavior.
-
-- `--diagram-file` - Path to `diagram.json` (defaults to project root)
-- `--timeout` - Simulation timeout in milliseconds (exit code 42 on timeout)
-- `--expect-text` - Exit successfully when this text appears in serial output
-- `--fail-text` - Exit with error when this text appears in serial output
-- `--expect-regex` - Exit successfully when this regex matches a serial output line
-- `--fail-regex` - Exit with error when this regex matches a serial output line
-
-### Example Usage
-
-```bash
-export WOKWI_CI_TOKEN="your-token-here"
-
-# Build and simulate
-idf.py build
-idf.py wokwi
-
-# CI mode: exit when expected text appears
-idf.py wokwi --timeout 10000 --expect-text "Hello world!"
-```
 
 ## Linting Diagrams
 

--- a/docs/wokwi-ci/idf-wokwi-usage.md
+++ b/docs/wokwi-ci/idf-wokwi-usage.md
@@ -1,0 +1,49 @@
+---
+title: ESP-IDF Simulation Extension Usage
+sidebar_label: ESP-IDF Simulation Extension
+descripton: idf-wokwi CLI command reference
+keywords: [esp-idf, idf, CLI, API, CI Dashboard, esp32, simulation]
+---
+
+The `idf-wokwi` Python package adds simulation support directly to Espressif's `idf.py` command. From `idf.py`, you can
+run a simulation and pass a selection of options to customize its behavior.
+
+Unlike `wokwi-cli`, you don't need to initalize a project as `idf-wokwi` will implicitly generate the relevant files
+(`wokwi.toml`/`diagram.json`) by inferring information from ESP-IDF. You can however still add your own files if you
+require other components.
+
+## Getting Started
+
+Create an API token on the [Wokwi CI Dashboard](https://wokwi.com/dashboard/ci). Set the `WOKWI_CLI_TOKEN` environment
+variable to the token value.
+
+Install the extension with the following command:
+```bash
+pip install idf-wokwi
+```
+
+You can now run a simulation by executing `idf.py wokwi`!
+
+## CLI Options
+
+Pass any selection of the following commands to `idf.py wokwi` to customize its behavior during runtime.
+
+- `--diagram-file` - Path to `diagram.json` (defaults to project root)
+- `--timeout` - Simulation timeout in milliseconds (exit code 42 on timeout)
+- `--expect-text` - Exit successfully when this text appears in serial output
+- `--fail-text` - Exit with error when this text appears in serial output
+- `--expect-regex` - Exit successfully when this regex matches a serial output line
+- `--fail-regex` - Exit with error when this regex matches a serial output line
+
+## Example Usage
+
+```bash
+export WOKWI_CI_TOKEN="your-token-here"
+
+# Build and simulate
+idf.py build
+idf.py wokwi
+
+# CI mode: exit when expected text appears
+idf.py wokwi --timeout 10000 --expect-text "Hello world!"
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -105,6 +105,7 @@ module.exports = {
       'wokwi-ci/getting-started',
       'wokwi-ci/cli-installation',
       'wokwi-ci/cli-usage',
+      'wokwi-ci/idf-wokwi-usage',
       'wokwi-ci/github-actions',
       'wokwi-ci/automation-scenarios',
       'wokwi-ci/mcp-support',


### PR DESCRIPTION
This PR adds references to `idf-wokwi` into the `wokwi-ci` pages - I wasn't too sure where it would fit best and I did think about putting it the ESP32 pages, but given that it's specifically about testing/simulation, it probably fits here best.