### PR TITLE
Document IR receiver supply voltage range

### DIFF
--- a/docs/parts/wokwi-ir-receiver.md
+++ b/docs/parts/wokwi-ir-receiver.md
@@ -9,11 +9,11 @@ sidebar_label: wokwi-ir-receiver
 
 ## Pin names
 
-| Name | Description      |
-| ---- | ---------------- |
-| GND  | Ground           |
-| VCC  | Positive voltage |
-| DAT  | Digital output   |
+| Name | Description                     |
+| ---- | ------------------------------- |
+| GND  | Ground                          |
+| VCC  | Positive voltage (2.7V to 5.5V) |
+| DAT  | Digital output                  |
 
 ## Using the receiver
 


### PR DESCRIPTION
## Summary

- document the IR receiver VCC range as 2.7V to 5.5V
- keep the pin table aligned with the repository's Prettier style

Addresses part of #107.

## Why

The pin table currently describes VCC only as "Positive voltage", so readers cannot tell which common microcontroller supply rails are appropriate. The documented range follows the operating supply specification for the OS-1838B 38kHz receiver, which matches this part's documented function.

Reference: [OS-1838B datasheet](https://www.hestore.eu/en/prod_getfile.php?id=12937)

## Validation

- `npx prettier --check docs/parts/wokwi-ir-receiver.md`
- `npm run build`
