### PR TITLE
docs(chips-api): add community logic analyzer example

### DIFF
--- a/docs/chips-api/getting-started.md
+++ b/docs/chips-api/getting-started.md
@@ -97,3 +97,4 @@ Make sure to include a newline ("\n") at the end of your `printf()` messages. Th
 
 - [CD4051B Multiplexer Example](https://wokwi.com/projects/343522915673702994) - Analog Multiplexer by Chris Schmidt
 - [PCA9685 Chip](https://wokwi.com/projects/348856116302578258) - 16-channel PWM driver over I2C by Bonny Rais
+- [Live 8-channel Logic Analyzer with Protocol Decoding](https://wokwi.com/projects/445513049908390913) - Live logic analyzer with UART, I²C and SPI decoding by Gil Tal ([GitHub](https://github.com/giltal/Wokwi-graphical-logic-analyzer))


### PR DESCRIPTION
This adds the logic analyzer showcased on [Discord](https://discord.com/channels/787627282663211009/1532122287703195738) to the Chips API examples