### PR TITLE
docs(wokwi-ci): explain valid token format

### DIFF
--- a/docs/wokwi-ci/cli-usage.md
+++ b/docs/wokwi-ci/cli-usage.md
@@ -23,6 +23,12 @@ wokwi-cli <your-project-directory>
 
 The CLI will start the simulation and display the serial output. It will automatically exit after 30 seconds.
 
+:::tip
+A valid Wokwi CLI token starts with `wok_` and is exactly 44 characters long (including the `wok_` prefix). If you are
+experiencing authorization issues, double check that your token is active, correctly formatted and doesn't contain any
+spaces or fancy characters.
+:::
+
 ## CLI Options
 
 You can use the following options to customize the CLI behavior:

--- a/docs/wokwi-ci/github-actions.md
+++ b/docs/wokwi-ci/github-actions.md
@@ -22,6 +22,12 @@ For a complete list of options, check out the [action's README](https://github.c
 
 You also need to set up the `WOKWI_CLI_TOKEN` secret in your repository settings. You can create an API token on the [Wokwi CI Dashboard](https://wokwi.com/dashboard/ci).
 
+:::tip
+A valid Wokwi CLI token starts with `wok_` and is exactly 44 characters long (including the `wok_` prefix). If you are
+experiencing authorization issues, double check that your token is active, correctly formatted and doesn't contain any
+spaces or fancy characters.
+:::
+
 ## Examples
 
 The following projects are set up to run on Wokwi CI. You can use them as a reference for your own projects. Check out the `.github/workflows` directory for the complete GitHub Action configuration in each example.


### PR DESCRIPTION
This commit adds a tooltip explaining the valid Wokwi CLI token format to the CLI usage and GitHub Actions page.